### PR TITLE
Fix fresh installs (pin gsplat) and warp on new NVIDIA drivers

### DIFF
--- a/gauss_gym/utils/warp_utils.py
+++ b/gauss_gym/utils/warp_utils.py
@@ -56,7 +56,6 @@ def ray_cast(ray_starts_world, ray_directions_world, wp_mesh):
     dtype=wp.vec3,
     shape=(num_rays,),
     copy=False,
-    owner=False,
     device=wp_mesh.device,
   )
   ray_directions_world_wp = wp.types.array(
@@ -64,7 +63,6 @@ def ray_cast(ray_starts_world, ray_directions_world, wp_mesh):
     dtype=wp.vec3,
     shape=(num_rays,),
     copy=False,
-    owner=False,
     device=wp_mesh.device,
   )
   ray_hits_world = torch.zeros((num_rays, 3), device=ray_starts_world.device)
@@ -74,7 +72,6 @@ def ray_cast(ray_starts_world, ray_directions_world, wp_mesh):
     dtype=wp.vec3,
     shape=(num_rays,),
     copy=False,
-    owner=False,
     device=wp_mesh.device,
   )
   wp.launch(
@@ -131,7 +128,6 @@ def nearest_point(points, wp_mesh):
     dtype=wp.vec3,
     shape=(num_points,),
     copy=False,
-    owner=False,
     device=wp_mesh.device,
   )
   mesh_points = torch.zeros((num_points, 3), device=points.device)
@@ -141,7 +137,6 @@ def nearest_point(points, wp_mesh):
     dtype=wp.vec3,
     shape=(num_points,),
     copy=False,
-    owner=False,
     device=wp_mesh.device,
   )
   wp.launch(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ dependencies = [
     "isaacgym",
     "viser==1.0.0",
     "plotly==6.2.0",
-    "warp-lang==1.7.1",
+    # 1.7.1 fails cuda_init on CUDA 13.x drivers (falls back to CPU); 1.10.1 is
+    # the last release supporting py3.8
+    "warp-lang==1.10.1",
     "ruamel.yaml==0.18.12",
     "wandb[media]==0.19.8",
     "plyfile==1.0.3",
@@ -29,7 +31,9 @@ dependencies = [
     "trimesh[recommend]==4.7.4",
     "scipy==1.10.1",
     "einops==0.8.0",
-    "gsplat @ git+https://github.com/nerfstudio-project/gsplat.git",
+    # gsplat master as of the gauss_gym release (2025-10-21); newer commits need
+    # CUDA >= 12.2 (cuda/std/optional) and pull in nvtx, which has no py3.8 wheels
+    "gsplat @ git+https://github.com/nerfstudio-project/gsplat.git@65042cc501d1cdbefaf1d6f61a9a47575eec8c71",
     "tensorflow-cpu==2.11.* ; platform_machine == 'x86_64' and python_version < '3.11'",
     "tdigest",
     "msgpack",


### PR DESCRIPTION
## Problem 1: fresh installs are broken

`pyproject.toml` pulls `gsplat` from unpinned git master. Since the release, gsplat master has drifted in two ways that break `setup_dev.sh` against the repo's pinned CUDA 12.1 / Python 3.8 toolchain:

1. it now depends on `nvtx`, and nvtx 0.2.15 (2026-03) dropped Python 3.8 wheels — its sdist also fails to build under py3.8-era setuptools (`project.license` metadata validation error);
2. newer gsplat kernels include `<cuda/std/optional>`, which requires CUDA >= 12.2 (`fatal error: cuda/std/optional: No such file or directory` with the env's CUDA 12.1).

**Fix:** pin gsplat to `65042cc`, the last master commit before the Oct 21, 2025 release — i.e. the exact code the release was developed against. Verified: `bash setup_dev.sh` completes from scratch again.

## Problem 2: warp silently falls back to CPU on new NVIDIA drivers (#16)

`warp-lang==1.7.1` fails `cuda_init` on CUDA 13.x drivers (575+/590):

```
Warp CUDA error: Failed to get driver entry point 'cuDeviceGetUuid' (CUDA error 1)
Warp CUDA error 36: API call is not supported in the installed CUDA driver (in function cuda_init)
```

Training still runs, but all mesh raycasting (terrain height sampling) quietly runs on CPU.

**Fix:** upgrade to `warp-lang==1.10.1` — the last release that supports Python 3.8. This requires dropping the `owner=` kwarg from the `wp.types.array()` calls in `gauss_gym/utils/warp_utils.py`: newer warp removed the parameter, and it was already the default in 1.7.x, so the change is compatible with both versions.

## Verification

On an RTX 5090 (driver 590.48.01, CUDA 13.1): fresh `setup_dev.sh` install, `gauss_train --task=t1` and `--task=t1_vision` (blind + vision) smoke runs, and `gauss_play` with a saved checkpoint — all clean, warp on `cuda:0`. Also relevant to #13; full notes on running on RTX 50-series posted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)